### PR TITLE
Add an SVG icon

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -24,7 +24,7 @@ export interface LayoutProps {
 
 const ShortcutPng: React.FC<{ size: number }> = ({ size }) => (
   <link
-    rel="shortcut icon"
+    rel="icon"
     href={`/images/icon${size}.png`}
     sizes={`${size}x${size}`}
     type="image/png"
@@ -77,7 +77,13 @@ const Layout: React.FC<LayoutProps> = ({
           content={description ?? DEFAULT_DESCRIPTION}
         />
         <meta name="description" content={description ?? DEFAULT_DESCRIPTION} />
-        {[64, 128, 256].map((size) => (
+        <link
+          rel="icon"
+          type="image/svg+xml"
+          sizes="any"
+          href="/images/icon128.svg"
+        />
+        {[256, 128, 64].map((size) => (
           <ShortcutPng key={size} size={size} />
         ))}
         <GoogleAnalytics />


### PR DESCRIPTION
See if changing the the order or adding an svg type will help with the blurry icon issue

<img width="94" alt="Screen Shot 2020-05-12 at 10 51 28 AM" src="https://user-images.githubusercontent.com/26596/81734494-703fb180-9448-11ea-871e-7ec22a7b754d.png">
