### PR TITLE
Add a build time context provider to all pages to solve #42

### DIFF
--- a/components/BuildTimeContext.tsx
+++ b/components/BuildTimeContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, useState, useEffect } from "react";
+
+export const BuildTimeContext = createContext<undefined | number>(undefined);
+
+export function useBuildTime(): number {
+  const buildTime = useContext(BuildTimeContext);
+  if (buildTime === undefined) {
+    throw new Error("Missing expected BuildTimeContext.Provider from Layout");
+  }
+  return buildTime;
+}
+
+export function useRenderTime(): number {
+  const buildTime = useBuildTime();
+  const [renderTime, setRenderTime] = useState(buildTime);
+  useEffect(() => setRenderTime(Date.now()), [buildTime]);
+  return renderTime;
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useMemo } from "react";
 import Head from "next/head";
@@ -11,8 +12,13 @@ import Lato from "./fonts/Lato";
 import Poppins from "./fonts/Poppins";
 import GoogleAnalytics from "./GoogleAnalytics";
 import absoluteUrl from "src/absoluteUrl";
+import { BuildTimeContext } from "./BuildTimeContext";
 
-export interface LayoutProps {
+export interface LayoutStaticProps {
+  buildTime: number;
+}
+
+export interface LayoutProps extends LayoutStaticProps {
   title: string;
   alerts?: React.ReactNode;
   headerChildren?: React.ReactNode;
@@ -34,7 +40,7 @@ const ShortcutPng: React.FC<{ size: number }> = ({ size }) => (
 const DEFAULT_DESCRIPTION: string =
   "Mission Bit is a 501(c)3 non-profit offering coding education and industry experiences to equip, empower and inspire public school youth to build products they dream up and broaden the opportunity horizon they envision for themselves.";
 
-const Layout: React.FC<LayoutProps> = ({
+export const Layout: React.FC<LayoutProps> = ({
   title,
   children,
   headerClassName,
@@ -43,6 +49,7 @@ const Layout: React.FC<LayoutProps> = ({
   alerts,
   pageImage,
   description,
+  buildTime,
 }) => {
   useEffect(() => {
     // Remove the server-side injected CSS.
@@ -54,7 +61,7 @@ const Layout: React.FC<LayoutProps> = ({
   const theme = useMemo(() => createMuiTheme(themeOptions), []);
   const router = useRouter();
   return (
-    <>
+    <BuildTimeContext.Provider value={buildTime}>
       <Head>
         <title>{title}</title>
         <meta charSet="utf-8" />
@@ -98,8 +105,13 @@ const Layout: React.FC<LayoutProps> = ({
         {children}
         <Footer className={footerClassName} />
       </ThemeProvider>
-    </>
+    </BuildTimeContext.Provider>
   );
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  const props: LayoutStaticProps = { buildTime: Date.now() };
+  return { props };
 };
 
 export default Layout;

--- a/components/events/index.tsx
+++ b/components/events/index.tsx
@@ -8,7 +8,7 @@ import Box from "@material-ui/core/Box";
 import GalaCalendarEvent from "components/gala/GalaDates";
 import { SpringClassInstances } from "components/programs/ClassInstanceData";
 import { MediumDateFormat } from "src/dates";
-import { useEffect, useState } from "react";
+import { useRenderTime } from "components/BuildTimeContext";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -101,8 +101,7 @@ const Upcoming: React.FC<{ date: string; href: string; className: string }> = ({
 
 const Main: React.FC<{}> = () => {
   const classes = useStyles();
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => setNow(Date.now()), []);
+  const now = useRenderTime();
   return (
     <Container component="main" id="main" className={classes.root}>
       <section id="current" className={classes.section}>

--- a/components/index/Alerts.tsx
+++ b/components/index/Alerts.tsx
@@ -2,11 +2,12 @@ import * as React from "react";
 import Link from "@material-ui/core/Link";
 import Alert from "@material-ui/lab/Alert";
 import Collapse from "@material-ui/core/Collapse";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { SummerDates } from "components/programs/ClassInstanceData";
 import { ShortDateFormat } from "src/dates";
 import { makeStyles, darken } from "@material-ui/core/styles";
 import { brand } from "src/colors";
+import { useRenderTime } from "components/BuildTimeContext";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -77,21 +78,18 @@ function firstAlert(now: number): React.ReactNode | undefined {
   )?.content;
 }
 
-const firstAlertNow = () => firstAlert(Date.now());
-
 const Alerts: React.FC<{}> = () => {
   const classes = useStyles();
-  const [alert, setAlert] = useState<React.ReactNode | undefined>(
-    firstAlertNow
-  );
-  useEffect(() => setAlert(firstAlertNow()), []);
+  const now = useRenderTime();
+  const [closed, setClosed] = useState<boolean>(false);
+  const alert = closed ? undefined : firstAlert(now);
   return (
     <Collapse in={alert !== undefined} className={classes.root}>
       <Alert
         severity="info"
         variant="filled"
         color="warning"
-        onClose={() => setAlert(undefined)}
+        onClose={() => setClosed(true)}
       >
         {alert}
       </Alert>

--- a/components/programs/Courses.tsx
+++ b/components/programs/Courses.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useState, useEffect } from "react";
 import Typography from "@material-ui/core/Typography";
 import {
   City,
@@ -17,6 +16,7 @@ import VioletButton from "components/VioletButton";
 import IndigoButton from "components/IndigoButton";
 import { brand } from "src/colors";
 import Button from "@material-ui/core/Button";
+import { useRenderTime } from "components/BuildTimeContext";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -341,8 +341,7 @@ function filterCourses(
 const Courses: React.FC<{
   instances: ClassOrWorkshopInstance[];
 }> = ({ children, instances }) => {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => setNow(Date.now()), []);
+  const now = useRenderTime();
   const courses = filterCourses(now, instances);
   return courses.length === 0 ? null : (
     <>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import { NextPage } from "next";
 import Container from "@material-ui/core/Container";
 import Typography from "@material-ui/core/Typography";
@@ -16,8 +16,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Page: NextPage<{}> = () => (
-  <Layout title="Mission Bit – 404 Not Found">
+const Page: NextPage<LayoutStaticProps> = (props) => (
+  <Layout {...props} title="Mission Bit – 404 Not Found">
     <Container component="main" className={useStyles().root}>
       <Typography variant="h1">HTTP 404 Not Found</Typography>
       <Typography>
@@ -30,4 +30,5 @@ const Page: NextPage<{}> = () => (
   </Layout>
 );
 
+export { getStaticProps };
 export default Page;

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,12 +1,13 @@
 import { NextPage } from "next";
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import About from "components/about";
 
-const Page: NextPage<{}> = () => (
-  <Layout title="Mission Bit – About Us">
+const Page: NextPage<LayoutStaticProps> = (props) => (
+  <Layout {...props} title="Mission Bit – About Us">
     <About />
   </Layout>
 );
 
+export { getStaticProps };
 export default Page;

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -1,12 +1,13 @@
 import { NextPage } from "next";
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import Events from "components/events";
 
-const Page: NextPage<{}> = () => (
-  <Layout title="Mission Bit – Events">
+const Page: NextPage<LayoutStaticProps> = (props) => (
+  <Layout {...props} title="Mission Bit – Events">
     <Events />
   </Layout>
 );
 
+export { getStaticProps };
 export default Page;

--- a/pages/gala/index.tsx
+++ b/pages/gala/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import Gala from "components/gala/Gala";
 import Banner from "components/gala/Banner";
 import oneLine from "src/oneLine";
@@ -11,8 +11,9 @@ impact, and learning. Join us for this inspiring event, meet our students,
 hear their stories, and help us reach our 2021 goals!
 `;
 
-const Page: NextPage<{}> = () => (
+const Page: NextPage<LayoutStaticProps> = (props) => (
   <Layout
+    {...props}
     title="Mission Bit – 2020 Mission Bit Gala"
     headerChildren={<Banner />}
     description={description}
@@ -22,4 +23,5 @@ const Page: NextPage<{}> = () => (
   </Layout>
 );
 
+export { getStaticProps };
 export default Page;

--- a/pages/gala/sponsorship.tsx
+++ b/pages/gala/sponsorship.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import Sponsorship from "components/gala/Sponsorship";
 import Banner from "components/gala/Banner";
 import oneLine from "src/oneLine";
@@ -11,8 +11,9 @@ impact, and learning. Join us for this inspiring event, meet our students,
 hear their stories, and help us reach our 2021 goals!
 `;
 
-const Page: NextPage<{}> = () => (
+const Page: NextPage<LayoutStaticProps> = (props) => (
   <Layout
+    {...props}
     title="Mission Bit – 2020 Mission Bit Gala Sponsorship"
     headerChildren={<Banner />}
     description={description}
@@ -22,4 +23,5 @@ const Page: NextPage<{}> = () => (
   </Layout>
 );
 
+export { getStaticProps };
 export default Page;

--- a/pages/get-involved.tsx
+++ b/pages/get-involved.tsx
@@ -1,12 +1,13 @@
 import { NextPage } from "next";
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import GetInvolved from "components/get-involved";
 
-const Page: NextPage<{}> = () => (
-  <Layout title="Mission Bit – Get Involved">
+const Page: NextPage<LayoutStaticProps> = (props) => (
+  <Layout {...props} title="Mission Bit – Get Involved">
     <GetInvolved />
   </Layout>
 );
 
+export { getStaticProps };
 export default Page;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import { NextPage } from "next";
 import * as React from "react";
 import { useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import Landing from "components/index/Landing";
 import Index from "components/index";
 import Alerts from "components/index/Alerts";
@@ -25,7 +25,7 @@ function updateDocumentSize() {
   el.style.setProperty("--document-height", `${el.clientHeight}px`);
 }
 
-const Page: NextPage<{}> = () => {
+const Page: NextPage<LayoutStaticProps> = (props) => {
   const classes = useStyles();
   useEffect(() => {
     updateDocumentSize();
@@ -34,6 +34,7 @@ const Page: NextPage<{}> = () => {
   }, []);
   return (
     <Layout
+      {...props}
       title="Mission Bit"
       alerts={<Alerts />}
       headerChildren={<Landing />}
@@ -44,4 +45,5 @@ const Page: NextPage<{}> = () => {
   );
 };
 
+export { getStaticProps };
 export default Page;

--- a/pages/laptop/index.tsx
+++ b/pages/laptop/index.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import { useRouter } from "next/router";
 import Container from "@material-ui/core/Container";
 
@@ -36,10 +36,11 @@ const QRCodeInfo: React.FC<{}> = () => {
   );
 };
 
-const Page: NextPage<{}> = () => (
-  <Layout title="Mission Bit – Laptop">
+const Page: NextPage<LayoutStaticProps> = (props) => (
+  <Layout {...props} title="Mission Bit – Laptop">
     <QRCodeInfo />
   </Layout>
 );
 
+export { getStaticProps };
 export default Page;

--- a/pages/laptop/windows.tsx
+++ b/pages/laptop/windows.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import Container from "@material-ui/core/Container";
 import { makeStyles } from "@material-ui/core/styles";
 
@@ -10,10 +10,10 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Page: NextPage<{}> = () => {
+const Page: NextPage<LayoutStaticProps> = (props) => {
   const classes = useStyles();
   return (
-    <Layout title="Mission Bit – Windows Laptops">
+    <Layout {...props} title="Mission Bit – Windows Laptops">
       <Container component="main">
         <h1>For existing MB laptops:</h1>
         <ol>
@@ -98,4 +98,5 @@ const Page: NextPage<{}> = () => {
   );
 };
 
+export { getStaticProps };
 export default Page;

--- a/pages/programs.tsx
+++ b/pages/programs.tsx
@@ -1,12 +1,13 @@
 import { NextPage } from "next";
 import * as React from "react";
-import Layout from "components/Layout";
+import { Layout, getStaticProps, LayoutStaticProps } from "components/Layout";
 import Programs from "components/programs";
 
-const Page: NextPage<{}> = () => (
-  <Layout title="Mission Bit – Programs">
+const Page: NextPage<LayoutStaticProps> = (props) => (
+  <Layout {...props} title="Mission Bit – Programs">
     <Programs />
   </Layout>
 );
 
+export { getStaticProps };
 export default Page;


### PR DESCRIPTION
Resolves #42

Apparently the way that Next.js works with React the render method must have a stable result between the client's first render on hydration and what was rendered statically so I'm passing a build time for each page through a context that we can use when we want to branch on a date.
