### PR TITLE
Gala copy edits

### DIFF
--- a/components/events/index.tsx
+++ b/components/events/index.tsx
@@ -265,12 +265,12 @@ const FeaturedEvents: FeaturedEvent[] = [
     date: Date.parse(GalaCalendarEvent.start),
     href: "/gala",
     linkTitle: "Learn More",
-    title: "Fourth Annual Gala",
+    title: "Fifth Annual Gala",
     description: (
       <>
-        Mission Bit’s Fourth Annual Gala is a celebration of seven years of
+        Mission Bit’s Fifth Annual Gala is a celebration of eight years of
         growth, impact, and learning. Join us for this inspiring event, meet our
-        students, hear their stories, and help us reach our 2021 goals!
+        students, hear their stories, and help us reach our 2022 goals!
       </>
     ),
     topRightImage: {

--- a/components/gala/Metadata.tsx
+++ b/components/gala/Metadata.tsx
@@ -5,11 +5,11 @@ import absoluteUrl from "src/absoluteUrl";
 import oneLine from "src/oneLine";
 import htmlEscapeJsonString from "src/htmlEscapeJsonString";
 
-export const title = "Mission Bit – 2020 Mission Bit Gala";
+export const title = "Mission Bit – 2021 Mission Bit Gala";
 export const description = oneLine`
-Mission Bit's Fourth Annual Gala is a celebration of seven years of growth,
+Mission Bit's Fifth Annual Gala is a celebration of eight years of growth,
 impact, and learning. Join us for this inspiring event, meet our students,
-hear their stories, and help us reach our 2021 goals!
+hear their stories, and help us reach our 2022 goals!
 `;
 export const pageImage = "/images/gala/2020-poster-save-the-date.jpg";
 export const registerUrl =

--- a/components/gala/SponsorDataNew.tsx
+++ b/components/gala/SponsorDataNew.tsx
@@ -57,7 +57,7 @@ export const Sponsors: readonly SponsorData[] = [
       width: 600,
       height: 600,
     }),
-    level: "silver",
+    level: "gold",
   },
 ];
 

--- a/components/gala/SponsorSection.tsx
+++ b/components/gala/SponsorSection.tsx
@@ -75,7 +75,7 @@ const SponsorSection: React.FC<{}> = () => {
         align="center"
         className={classes.thankYouHeading}
       >
-        Thank you to our 2020 Gala Sponsors
+        Thank you to our 2021 Gala Sponsors
       </Typography>
       {SponsorLevels.map((level) => {
         const sponsors = Sponsors.filter((props) => props.level === level);

--- a/components/index/Alerts.tsx
+++ b/components/index/Alerts.tsx
@@ -8,7 +8,6 @@ import { ShortDateFormat } from "src/dates";
 import { makeStyles, darken } from "@material-ui/core/styles";
 import { brand } from "src/colors";
 import { useRenderTime } from "components/BuildTimeContext";
-import GalaCalendarEvent from "components/gala/GalaDates";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -58,21 +57,6 @@ interface TimedAlert {
 }
 
 const timedAlerts: readonly TimedAlert[] = [
-  {
-    hideAfter: Date.parse(GalaCalendarEvent.end!),
-    content: (
-      <Link color="inherit" href="/gala?aff=banner" title="Mission Bit Gala">
-        <span role="img" aria-label="Party popper">
-          🎉
-        </span>{" "}
-        Join Mayors Michael Tubbs and London Breed at our Annual (Virtual) Gala
-        on November 12{" "}
-        <span role="img" aria-label="Partying face">
-          🥳
-        </span>
-      </Link>
-    ),
-  },
   {
     hideAfter: CourseDates.registrationDeadline,
     content: (

--- a/pages/gala/sponsorship.tsx
+++ b/pages/gala/sponsorship.tsx
@@ -5,15 +5,15 @@ import Sponsorship from "components/gala/Sponsorship";
 import oneLine from "src/oneLine";
 
 const description = oneLine`
-Mission Bit's Fourth Annual Gala is a celebration of seven years of growth,
+Mission Bit's Fifth Annual Gala is a celebration of eight years of growth,
 impact, and learning. Join us for this inspiring event, meet our students,
-hear their stories, and help us reach our 2021 goals!
+hear their stories, and help us reach our 2022 goals!
 `;
 
 const Page: NextPage<LayoutStaticProps> = (props) => (
   <Layout
     {...props}
-    title="Mission Bit – 2020 Mission Bit Gala Sponsorship"
+    title="Mission Bit – 2021 Mission Bit Gala Sponsorship"
     description={description}
     pageImage="/images/gala/2020-poster-save-the-date.jpg"
   >


### PR DESCRIPTION
* Remove alert on homepage (2020 gala resurfaced because the date changed)
* missionbit.org/events says fourth annual rather than fifth annual
* missionbit.org/gala Verizon is a gold sponsor not silver